### PR TITLE
Relax dependency on base

### DIFF
--- a/c-dsl.cabal
+++ b/c-dsl.cabal
@@ -24,8 +24,8 @@ library
                         Language.C.DSL.Exp,
                         Language.C.DSL.StringLike
   
-  build-depends:       base ==4.*,
-                       language-c == 0.4.*
+  build-depends:       base >= 4.0.0,
+                       language-c
   hs-source-dirs:      src/
   default-language:    Haskell2010
   


### PR DESCRIPTION
This is so that the package builds on the latest base.